### PR TITLE
Fix failed running ssd-mobilenet throughput testing

### DIFF
--- a/models/object_detection/tensorflow/ssd-mobilenet/inference/int8/run_frozen_graph_ssdmob.py
+++ b/models/object_detection/tensorflow/ssd-mobilenet/inference/int8/run_frozen_graph_ssdmob.py
@@ -183,7 +183,7 @@ def run_inference_for_single_image(graph):
 
         if (args.evaluate_tensor is not None):
           for tensor in output_dict[args.evaluate_tensor]:
-            print tensor.shape
+            print(tensor.shape)
           return None, None
 
         # all outputs are float32 numpy arrays, so convert types as appropriate


### PR DESCRIPTION
Failed running ssd-mobilenet  run_frozen_graph_ssdmob.py in python3 because of the print Syntax
Here is the deatil error message
```
  File "/workspace/intelai_models/inference/int8/run_frozen_graph_ssdmob.py", line 186
    print tensor.shape
               ^
SyntaxError: Missing parentheses in call to 'print'

```
Change the Syntax to support python3