### PR TITLE
fix: only split once to recognize kmp_affinity correctly

### DIFF
--- a/benchmarks/launch_benchmark.py
+++ b/benchmarks/launch_benchmark.py
@@ -202,7 +202,7 @@ class LaunchBenchmark(base_benchmark_util.BaseBenchmarkUtil):
                 raise ValueError("Expected model args in the format "
                                  "`name=value` but received: {}".
                                  format(custom_arg))
-            split_arg = custom_arg.split("=")
+            split_arg = custom_arg.split("=", 1)
             split_arg[0] = split_arg[0].replace("-", "_")
             env_var_dict[split_arg[0]] = split_arg[1]
 


### PR DESCRIPTION
Problem: kmp_affinity in command line like below can't be recognized correctly.
```
kmp_affinity="noverbose,granularity=core"
```
if not force the split time, this command will be broke to two parts and OpenMP will ignore them.
* kmp_affinity=noverbose,granularity
* core