### PR TITLE
solve int8 inceptionv3 and int8 mobilenet_v1 benchmark error on windows

### DIFF
--- a/models/image_recognition/tensorflow/inceptionv3/int8/benchmark.py
+++ b/models/image_recognition/tensorflow/inceptionv3/int8/benchmark.py
@@ -147,13 +147,13 @@ if __name__ == "__main__":
 
   print("[Running warmup steps...]")
   for t in range(warmup_steps):
-    data_start_time = time.time()
+    data_start_time = time.perf_counter()
     image_data = data_sess.run(images)
-    data_load_time = time.time() - data_start_time
+    data_load_time = time.perf_counter() - data_start_time
 
-    start_time = time.time()
+    start_time = time.perf_counter()
     infer_sess.run(output_tensor, {input_tensor: image_data})
-    elapsed_time = time.time() - start_time
+    elapsed_time = time.perf_counter() - start_time
 
     # only count the data loading and processing time for real data
     if args.data_location:
@@ -169,13 +169,13 @@ if __name__ == "__main__":
 
   for t in range(steps):
     try:
-      data_start_time = time.time()
+      data_start_time = time.perf_counter()
       image_data = data_sess.run(images)
-      data_load_time = time.time() - data_start_time
+      data_load_time = time.perf_counter() - data_start_time
 
-      start_time = time.time()
+      start_time = time.perf_counter()
       infer_sess.run(output_tensor, {input_tensor: image_data})
-      elapsed_time = time.time() - start_time
+      elapsed_time = time.perf_counter() - start_time
 
       # only count the data loading and processing time for real data
       if args.data_location:

--- a/models/image_recognition/tensorflow/mobilenet_v1/inference/int8/benchmark.py
+++ b/models/image_recognition/tensorflow/mobilenet_v1/inference/int8/benchmark.py
@@ -126,9 +126,9 @@ if __name__ == "__main__":
     sys.stdout.flush()
     print("[Running warmup steps...]")
     for t in range(warmup_steps):
-      start_time = time.time()
+      start_time = time.perf_counter()
       sess.run(output_tensor, {input_tensor: image_data})
-      elapsed_time = time.time() - start_time
+      elapsed_time = time.perf_counter() - start_time
       if((t+1) % 10 == 0):
         print("steps = {0}, {1} images/sec"
               "".format(t+1, batch_size/elapsed_time))
@@ -137,9 +137,9 @@ if __name__ == "__main__":
     total_time   = 0;
     total_images = 0;
     for t in range(steps):
-      start_time = time.time()
+      start_time = time.perf_counter()
       results = sess.run(output_tensor, {input_tensor: image_data})
-      elapsed_time = time.time() - start_time
+      elapsed_time = time.perf_counter() - start_time
       total_time = total_time + elapsed_time
 
       if((t+1) % 10 == 0):


### PR DESCRIPTION
use time.perf_counter() to replace time.time() to the int8 inceptionv3 and int8 mobilenet_v1 solve benchmark issue on windows 