### PR TITLE
Update README.md

### DIFF
--- a/quickstart/image_recognition/tensorflow/resnet50v1_5/training/gpu/README.md
+++ b/quickstart/image_recognition/tensorflow/resnet50v1_5/training/gpu/README.md
@@ -31,7 +31,7 @@ Intel® Extension for TensorFlow* with Intel® Data Center GPU Max Series.
 <!--- 30. Datasets -->
 ## Datasets
 
-Download and preprocess the ImageNet dataset using the [instructions here](datasets/imagenet/README.md).
+Download and preprocess the ImageNet dataset using the [instructions here](https://github.com/IntelAI/models/blob/master/datasets/imagenet/README.md).
 After running the conversion script you should have a directory with the
 ImageNet dataset in the TF records format.
 


### PR DESCRIPTION
the original ImageNet dataset link is broken. 
https://github.com/IntelAI/models/blob/master/quickstart/image_recognition/tensorflow/resnet50v1_5/training/gpu/datasets/imagenet/README.md

fix it with correct link: 
https://github.com/IntelAI/models/blob/master/datasets/imagenet/README.md