### PR TITLE
<DLRMv2> Add return of construct_model in dlrm_main.py

### DIFF
--- a/models/recommendation/pytorch/torchrec_dlrm/dlrm_main.py
+++ b/models/recommendation/pytorch/torchrec_dlrm/dlrm_main.py
@@ -1285,6 +1285,7 @@ def construct_model(args):
         lr_scheduler = LRPolicyScheduler(
             optimizer, args.lr_warmup_steps, args.lr_decay_start, args.lr_decay_steps
         )
+    return model, optimizer, lr_scheduler
 
 def main(argv: List[str]) -> None:
     """


### PR DESCRIPTION
Inference DLRMv2 on CPU using dlrm_main.py
Issue: 
```
model, optimizer, lr_scheduler = construct_model(args)
TypeError: cannot unpack non-iterable NoneType object
```
This PR is for this issue fixing.
